### PR TITLE
Cassandra backend fix

### DIFF
--- a/beaker_extensions/cassandra.py
+++ b/beaker_extensions/cassandra.py
@@ -51,8 +51,8 @@ class CassandraManager(NoSqlManager):
 
     def __getitem__(self, key):
         try:
-            result = self.cf.get(key)
-            return result['data']
+            result = self.cf.get(self._format_key(key))
+            return pickle.loads(result['data'])
         except pycassa.NotFoundException:
             return None
 


### PR DESCRIPTION
Because of stupid mistake session loading failed silently.
Added key formatting and data unpickling to CassandraManager.**getitem**() method.
Please merge.
