### PR TITLE
Force using of redis expiration time …

### DIFF
--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -26,7 +26,7 @@ class RedisManager(NoSqlManager):
     def set_value(self, key, value, expiretime=None):
         key = self._format_key(key)
         if expiretime:
-            self.db_conn.setex(key, expiretime, pickle.dumps(value))
+            self.db_conn.setex(key, pickle.dumps(value), expiretime)
         else:
             self.db_conn.set(key, pickle.dumps(value))
 

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -25,6 +25,14 @@ class RedisManager(NoSqlManager):
 
     def set_value(self, key, value, expiretime=None):
         key = self._format_key(key)
+
+        #XXX: beaker.container.Value.set_value calls NamespaceManager.set_value
+        #     however it(until version 1.6.3) never sets expiretime param. Why?
+        #     Fortunately we can access expiretime through value.
+        #     >>> value = list(storedtime, expire_argument, real_value)
+        if expiretime is None:
+            expiretime = value[1]
+
         if expiretime:
             self.db_conn.setex(key, pickle.dumps(value), expiretime)
         else:


### PR DESCRIPTION
_beaker.container.Value.set_value_ calls _NamespaceManager.set_value_, however it(until version 1.6.3) never sets _expiretime_ param. [1]
Fortunately we can access expiretime through _value_ since _value_ is a _list_: 

``` python
value = list(storedtime, expire_argument, real_value)
```

Also, because of this behavior, the _redis.setex_ has never been called and it was wrong 

[1] https://bitbucket.org/bbangert/beaker/src/d1757ad53763/beaker/container.py#cl-416

PS: Because redis is an "in memory" NoSQL, server may run out of memory since that beaker (until version 1.6.3) nerver delete expired keys.
