### PR TITLE
Fix for double call to format_key in RedisManager.__delitem__

### DIFF
--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -39,7 +39,6 @@ class RedisManager(NoSqlManager):
             self.db_conn.set(key, pickle.dumps(value))
 
     def __delitem__(self, key):
-        key = self._format_key(key)
         self.db_conn.delete(self._format_key(key))
 
     def _format_key(self, key):


### PR DESCRIPTION
A fix for long present bug preventing clearing sessions while using redis backend - I just deleted one line
