### PR TITLE
Redis namespace manager fixes

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,7 @@ Install directly from git using PIP:
 
     pip install git+git://github.com/bbangert/beaker_extensions.git
 
-Now you can use the redis, tyrant, riak, dynomite, and ringo extensions.
+Now you can use the couchdb, redis, tyrant, riak, dynomite, and ringo extensions.
 
 beaker.session.type = tyrant
 beaker.session.url = 127.0.0.1:1978

--- a/README
+++ b/README
@@ -11,3 +11,17 @@ beaker.session.url = 127.0.0.1:1978
 
 Thanks to Jack Hsu for providing the tokyo example:
 http://www.jackhsu.com/2009/05/27/pylons-with-tokyo-cabinet-beaker-sessions
+
+== Information for CouchDB backend =============================================
+
+beaker.session.type = couchdb
+beaker.session.url = localhost:5984
+beaker.session.database = project_session_dbname
+
+Note:
+    The CouchDB backend is modified from the redis_.py backend. Included test
+script is modified from test_database.py in beaker library. To run the test,
+CouchDB must be at localhost:5984 and in admin party mode. Test script will
+attempt to create a database named 'beaker_extension_test'.
+    Documents of sessions have keys similar to 'beaker:sha-hash:session', and
+'type' fields set to 'beaker.session'.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,24 @@ Install directly from git using PIP:
 pip install git+git://github.com/didip/beaker_extensions.git
 ```
 
-Now you can use the redis, tyrant, riak, dynomite, and ringo extensions.
+Now you can use the couchdb, redis, tyrant, riak, dynomite, and ringo extensions.
 
 beaker.session.type = tyrant
 beaker.session.url = 127.0.0.1:1978
 
 Thanks to Jack Hsu for providing the tokyo example:
 http://www.jackhsu.com/2009/05/27/pylons-with-tokyo-cabinet-beaker-sessions
+
+== Information for CouchDB backend =============================================
+
+beaker.session.type = couchdb
+beaker.session.url = localhost:5984
+beaker.session.database = project_session_dbname
+
+Note:
+    The CouchDB backend is modified from the redis_.py backend. Included test
+script is modified from test_database.py in beaker library. To run the test,
+CouchDB must be at localhost:5984 and in admin party mode. Test script will
+attempt to create a database named 'beaker_extension_test'.
+    Documents of sessions have keys similar to 'beaker:sha-hash:session', and
+'type' fields set to 'beaker.session'.

--- a/beaker_extensions/cassandra.py
+++ b/beaker_extensions/cassandra.py
@@ -72,4 +72,4 @@ class CassandraManager(NoSqlManager):
 
 
 class CassandraContainer(Container):
-    namespace_manager = CassandraManager
+    namespace_class = CassandraManager

--- a/beaker_extensions/couchdb_.py
+++ b/beaker_extensions/couchdb_.py
@@ -45,7 +45,13 @@ class CouchDBManager(NoSqlManager):
             doc['_id'] = key
             doc['type'] = 'beaker.session'
         doc['value'] = pickle.dumps(value)
-        self.db_conn.save(doc)
+        while True:
+            try:
+                self.db_conn.save(doc)
+                break
+            except ResourceConflict:
+                doc = self.db_conn[key]
+                doc['value'] = pickle.dumps(value)
 
     def __delitem__(self, key):
         key = self._format_key(key)

--- a/beaker_extensions/couchdb_.py
+++ b/beaker_extensions/couchdb_.py
@@ -1,0 +1,78 @@
+import logging
+from beaker.exceptions import InvalidCacheBackendError
+
+from beaker_extensions.nosql import Container
+from beaker_extensions.nosql import NoSqlManager
+from beaker_extensions.nosql import pickle
+
+try:
+    import couchdb
+    from couchdb.mapping import Document
+    from couchdb.http import ResourceNotFound, ResourceConflict
+except ImportError:
+    raise InvalidCacheBackendError("CouchDB cache backend requires the 'couchdb-python' library")
+
+log = logging.getLogger(__name__)
+
+class CouchDBManager(NoSqlManager):
+    def __init__(self, namespace, url=None, data_dir=None, lock_dir=None, **params):
+        self.database = params['database']
+        NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params)
+
+    def open_connection(self, host, port, **params):
+        self.db_conn = couchdb.Server('http://'+host+':'+str(port)+'/')[self.database]
+
+    def __contains__(self, key):
+        key = self._format_key(key)
+        try:
+            doc = self.db_conn[key]
+        except ResourceNotFound:
+            return False
+        return True
+
+    def __getitem__(self, key):
+        try:
+            return pickle.loads(self.db_conn[self._format_key(key)]['value'])
+        except ResourceNotFound:
+            return None
+
+    def set_value(self, key, value):
+        key = self._format_key(key)
+        doc = {}
+        try:
+            doc = self.db_conn[key]
+        except ResourceNotFound:
+            doc['_id'] = key
+            doc['type'] = 'beaker.session'
+        doc['value'] = pickle.dumps(value)
+        while True:
+            try:
+                self.db_conn.save(doc)
+                break
+            except ResourceConflict:
+                doc = self.db_conn[key]
+                doc['value'] = pickle.dumps(value)
+
+    def __delitem__(self, key):
+        key = self._format_key(key)
+        doc = self.db_conn[key]
+        self.db_conn.delete(doc)
+
+    def _format_key(self, key):
+        return 'beaker:%s:%s' % (self.namespace, key.replace(' ', '\302\267'))
+
+    def do_remove(self):
+        map_fun = '''function(doc) {
+            if (doc.type == 'beaker.session')
+                emit(doc.id, null);
+        }'''
+        for row in self.db_conn.query(map_fun):
+            doc = self.db_conn.get(row.id)
+            self.db_conn.delete(doc)
+
+    def keys(self):
+        raise Exception("Unimplemented")
+
+
+class CouchDBContainer(Container):
+    namespace_manager = CouchDBManager

--- a/beaker_extensions/couchdb_.py
+++ b/beaker_extensions/couchdb_.py
@@ -31,7 +31,10 @@ class CouchDBManager(NoSqlManager):
         return True
 
     def __getitem__(self, key):
-        return pickle.loads(self.db_conn[self._format_key(key)]['value'])
+        try:
+            return pickle.loads(self.db_conn[self._format_key(key)]['value'])
+        except ResourceNotFound:
+            return None
 
     def set_value(self, key, value):
         key = self._format_key(key)

--- a/beaker_extensions/couchdb_.py
+++ b/beaker_extensions/couchdb_.py
@@ -1,0 +1,72 @@
+import logging
+from beaker.exceptions import InvalidCacheBackendError
+
+from beaker_extensions.nosql import Container
+from beaker_extensions.nosql import NoSqlManager
+from beaker_extensions.nosql import pickle
+
+try:
+    import couchdb
+    from couchdb.mapping import Document
+    from couchdb.http import ResourceNotFound, ResourceConflict
+except ImportError:
+    raise InvalidCacheBackendError("CouchDB cache backend requires the 'couchdb-python' library")
+
+log = logging.getLogger(__name__)
+
+class CouchDBManager(NoSqlManager):
+    def __init__(self, namespace, url=None, data_dir=None, lock_dir=None, **params):
+        self.database = params['database']
+        NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params)
+
+    def open_connection(self, host, port, **params):
+        self.db_conn = couchdb.Server('http://'+host+':'+str(port)+'/')[self.database]
+
+    def __contains__(self, key):
+        key = self._format_key(key)
+        try:
+            doc = self.db_conn[key]
+        except ResourceNotFound:
+            return False
+        return True
+
+    def __getitem__(self, key):
+        try:
+            return pickle.loads(self.db_conn[self._format_key(key)]['value'])
+        except ResourceNotFound:
+            return None
+
+    def set_value(self, key, value):
+        key = self._format_key(key)
+        doc = {}
+        try:
+            doc = self.db_conn[key]
+        except ResourceNotFound:
+            doc['_id'] = key
+            doc['type'] = 'beaker.session'
+        doc['value'] = pickle.dumps(value)
+        self.db_conn.save(doc)
+
+    def __delitem__(self, key):
+        key = self._format_key(key)
+        doc = self.db_conn[key]
+        self.db_conn.delete(doc)
+
+    def _format_key(self, key):
+        return 'beaker:%s:%s' % (self.namespace, key.replace(' ', '\302\267'))
+
+    def do_remove(self):
+        map_fun = '''function(doc) {
+            if (doc.type == 'beaker.session')
+                emit(doc.id, null);
+        }'''
+        for row in self.db_conn.query(map_fun):
+            doc = self.db_conn.get(row.id)
+            self.db_conn.delete(doc)
+
+    def keys(self):
+        raise Exception("Unimplemented")
+
+
+class CouchDBContainer(Container):
+    namespace_manager = CouchDBManager

--- a/beaker_extensions/couchdb_.py
+++ b/beaker_extensions/couchdb_.py
@@ -1,0 +1,62 @@
+import logging
+from beaker.exceptions import InvalidCacheBackendError
+
+from beaker_extensions.nosql import Container
+from beaker_extensions.nosql import NoSqlManager
+from beaker_extensions.nosql import pickle
+
+try:
+    import couchdb
+    from couchdb.mapping import Document
+    from couchdb.http import ResourceNotFound, ResourceConflict
+except ImportError:
+    raise InvalidCacheBackendError("CouchDB cache backend requires the 'couchdb-python' library")
+
+log = logging.getLogger(__name__)
+
+class CouchDBManager(NoSqlManager):
+    def __init__(self, namespace, url=None, data_dir=None, lock_dir=None, **params):
+        self.database = params['database']
+        NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params)
+
+    def open_connection(self, host, port, **params):
+        self.db_conn = couchdb.Server('http://'+host+':'+str(port)+'/')[self.database]
+
+    def __contains__(self, key):
+        key = self._format_key(key)
+        try:
+            doc = self.db_conn[key]
+        except ResourceNotFound:
+            return False
+        return True
+
+    def __getitem__(self, key):
+        return pickle.loads(self.db_conn[self._format_key(key)]['value'])
+
+    def set_value(self, key, value):
+        key = self._format_key(key)
+        doc = {}
+        try:
+            doc = self.db_conn[key]
+        except ResourceNotFound:
+            doc['_id'] = key
+        doc['value'] = pickle.dumps(value)
+        self.db_conn.save(doc)
+
+    def __delitem__(self, key):
+        key = self._format_key(key)
+        doc = self.db_conn[key]
+        self.db_conn.delete(doc)
+
+    def _format_key(self, key):
+        return 'beaker:%s:%s' % (self.namespace, key.replace(' ', '\302\267'))
+
+    def do_remove(self):
+        raise Exception("Unimplemented")
+
+    def keys(self):
+        raise Exception("Unimplemented")
+
+
+class CouchDBContainer(Container):
+    namespace_manager = CouchDBManager

--- a/beaker_extensions/dynomite_.py
+++ b/beaker_extensions/dynomite_.py
@@ -51,4 +51,4 @@ class DynomiteManager(NoSqlManager):
 
 
 class DynomiteContainer(Container):
-    namespace_manager = DynomiteManager
+    namespace_class = DynomiteManager

--- a/beaker_extensions/nosql.py
+++ b/beaker_extensions/nosql.py
@@ -23,7 +23,7 @@ class NoSqlManager(NamespaceManager):
             self.lock_dir = lock_dir
         elif data_dir:
             self.lock_dir = data_dir + "/container_tcd_lock"
-        if self.lock_dir:
+        if hasattr(self, 'lock_dir'):
             verify_directory(self.lock_dir)           
 
         conn_params = {}

--- a/beaker_extensions/nosql.py
+++ b/beaker_extensions/nosql.py
@@ -23,7 +23,10 @@ class NoSqlManager(NamespaceManager):
             self.lock_dir = lock_dir
         elif data_dir:
             self.lock_dir = data_dir + "/container_tcd_lock"
-        if hasattr(self, 'lock_dir'):
+        else:
+            self.lock_dir = None
+            
+        if self.lock_dir:
             verify_directory(self.lock_dir)           
 
         conn_params = {}

--- a/beaker_extensions/nosql.py
+++ b/beaker_extensions/nosql.py
@@ -23,6 +23,9 @@ class NoSqlManager(NamespaceManager):
             self.lock_dir = lock_dir
         elif data_dir:
             self.lock_dir = data_dir + "/container_tcd_lock"
+        else:
+            self.lock_dir = None
+            
         if self.lock_dir:
             verify_directory(self.lock_dir)           
 

--- a/beaker_extensions/nosql.py
+++ b/beaker_extensions/nosql.py
@@ -73,4 +73,4 @@ class NoSqlManager(NamespaceManager):
 
 
 class NoSqlManagerContainer(Container):
-    namespace_manager = NoSqlManager
+    namespace_class = NoSqlManager

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -20,6 +20,10 @@ class RedisManager(NoSqlManager):
         self.db_conn = Redis(host=host, port=int(port), **params)
 
     def __contains__(self, key):
+<<<<<<< HEAD
+=======
+        log.debug('%s contained in redis cache (as %s) : %s'%(key, self._format_key(key), self.db_conn.exists(self._format_key(key))))
+>>>>>>> 8af0f1128a9c357542fd087e3cb3336f35bf1f7f
         return self.db_conn.exists(self._format_key(key))
 
     def set_value(self, key, value):

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -14,13 +14,14 @@ log = logging.getLogger(__name__)
 
 class RedisManager(NoSqlManager):
     def __init__(self, namespace, url=None, data_dir=None, lock_dir=None, **params):
-        self.db = params.pop('db', None)
+        self.connection_pool = params.pop('connection_pool', None)
         NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params)
 
     def open_connection(self, host, port, **params):
-        self.db_conn = StrictRedis(host=host, port=int(port), db=self.db, **params)
+        self.db_conn = Redis(host=host, port=int(port), connection_pool=self.connection_pool, **params)
 
     def __contains__(self, key):
+        log.debug('%s contained in redis cache (as %s) : %s'%(key, self._format_key(key), self.db_conn.exists(self._format_key(key))))
         return self.db_conn.exists(self._format_key(key))
 
     def set_value(self, key, value, expiretime=None):

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -20,6 +20,7 @@ class RedisManager(NoSqlManager):
         self.db_conn = Redis(host=host, port=int(port), **params)
 
     def __contains__(self, key):
+        log.debug('%s contained in redis cache (as %s) : %s'%(key, self._format_key(key), self.db_conn.exists(self._format_key(key))))
         return self.db_conn.exists(self._format_key(key))
 
     def set_value(self, key, value):

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -29,7 +29,7 @@ class RedisManager(NoSqlManager):
 
     def __delitem__(self, key):
         key = self._format_key(key)
-        self.db_conn.delete(self._format_key(key))
+        self.db_conn.delete(key)
 
     def _format_key(self, key):
         return 'beaker:%s:%s' % (self.namespace, key.replace(' ', '\302\267'))

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -52,4 +52,4 @@ class RedisManager(NoSqlManager):
 
 
 class RedisContainer(Container):
-    namespace_manager = RedisManager
+    namespace_class = RedisManager

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -20,7 +20,6 @@ class RedisManager(NoSqlManager):
         self.db_conn = Redis(host=host, port=int(port), **params)
 
     def __contains__(self, key):
-        key = self._format_key(key)
         return self.db_conn.exists(self._format_key(key))
 
     def set_value(self, key, value):

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -20,10 +20,7 @@ class RedisManager(NoSqlManager):
         self.db_conn = Redis(host=host, port=int(port), **params)
 
     def __contains__(self, key):
-<<<<<<< HEAD
-=======
         log.debug('%s contained in redis cache (as %s) : %s'%(key, self._format_key(key), self.db_conn.exists(self._format_key(key))))
->>>>>>> 8af0f1128a9c357542fd087e3cb3336f35bf1f7f
         return self.db_conn.exists(self._format_key(key))
 
     def set_value(self, key, value):

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -14,10 +14,11 @@ log = logging.getLogger(__name__)
 
 class RedisManager(NoSqlManager):
     def __init__(self, namespace, url=None, data_dir=None, lock_dir=None, **params):
+        self.connection_pool = params.pop('connection_pool', None)
         NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params)
 
     def open_connection(self, host, port, **params):
-        self.db_conn = Redis(host=host, port=int(port), **params)
+        self.db_conn = Redis(host=host, port=int(port), connection_pool=self.connection_pool, **params)
 
     def __contains__(self, key):
         log.debug('%s contained in redis cache (as %s) : %s'%(key, self._format_key(key), self.db_conn.exists(self._format_key(key))))

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -28,10 +28,6 @@ class RedisManager(NoSqlManager):
 
         #XXX: beaker.container.Value.set_value calls NamespaceManager.set_value
         # however it(until version 1.6.3) never sets expiretime param. Why?
-        # Fortunately we can access expiretime through value.
-        # >>> value = list(storedtime, expire_argument, real_value)
-        if expiretime is None:
-            expiretime = value[1]
 
         if expiretime:
             self.db_conn.setex(key, expiretime, pickle.dumps(value))

--- a/beaker_extensions/riak.py
+++ b/beaker_extensions/riak.py
@@ -42,4 +42,4 @@ class RiakManager(NoSqlManager):
 
 
 class RiakContainer(Container):
-    namespace_manager = RiakManager
+    namespace_class = RiakManager

--- a/beaker_extensions/ringo.py
+++ b/beaker_extensions/ringo.py
@@ -40,4 +40,4 @@ class RingoManager(NoSqlManager):
 
 
 class RingoContainer(Container):
-    namespace_manager = RingoManager
+    namespace_class = RingoManager

--- a/beaker_extensions/tyrant_.py
+++ b/beaker_extensions/tyrant_.py
@@ -37,4 +37,4 @@ class TokyoTyrantManager(NoSqlManager):
 
 
 class TokyoTyrantContainer(Container):
-    namespace_manager = TokyoTyrantManager
+    namespace_class = TokyoTyrantManager

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
 [egg_info]
 tag_build = dev
 tag_svn_revision = true
+
+[nosetests]
+tests=tests/test_couchdb.py
+verbose=True
+detailed-errors=True

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(name='beaker_extensions',
       redis = beaker_extensions.redis_:RedisManager
       ringo = beaker_extensions.ringo:RingoManager
       tyrant = beaker_extensions.tyrant_:TokyoTyrantManager
+      couchdb = beaker_extensions.couchdb_:CouchDBManager
       """,
       )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import sys, os
 
 version = '0.1.2'
 
+tests_require = ['nose', 'webtest']
+
 setup(name='beaker_extensions',
       version=version,
       description="Beaker extensions for additional back-end stores.",
@@ -20,6 +22,8 @@ setup(name='beaker_extensions',
       install_requires=[
           # -*- Extra requirements: -*-
       ],
+      test_suite='nose.collector',
+      tests_require=tests_require,
       entry_points="""
       # -*- Entry points: -*-
       [beaker.backends]
@@ -28,5 +32,6 @@ setup(name='beaker_extensions',
       riak = beaker_extensions.riak:RiakManager
       dynomite = beaker_extensions.dynomite_:DynomiteManager
       ringo = beaker_extensions.ringo:RingoManager
+      couchdb = beaker_extensions.couchdb_:CouchDBManager
       """,
       )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import sys, os
 
 version = '0.2.0'
 
+tests_require = ['nose', 'webtest']
+
 setup(name='beaker_extensions',
       version=version,
       description="Beaker extensions for additional back-end stores.",
@@ -20,6 +22,8 @@ setup(name='beaker_extensions',
       install_requires=[
           # -*- Extra requirements: -*-
       ],
+      test_suite='nose.collector',
+      tests_require=tests_require,
       entry_points="""
       # -*- Entry points: -*-
       [beaker.backends]
@@ -29,5 +33,6 @@ setup(name='beaker_extensions',
       dynomite = beaker_extensions.dynomite_:DynomiteManager
       ringo = beaker_extensions.ringo:RingoManager
       cassandra = beaker_extensions.cassandra:CassandraManager
+      couchdb = beaker_extensions.couchdb_:CouchDBManager
       """,
       )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '0.11'
+version = '0.1.2'
 
 setup(name='beaker_extensions',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import sys, os
 
 version = '0.1'
 
+tests_require = ['nose', 'webtest']
+
 setup(name='beaker_extensions',
       version=version,
       description="Beaker extensions for additional back-end stores.",
@@ -20,6 +22,8 @@ setup(name='beaker_extensions',
       install_requires=[
           # -*- Extra requirements: -*-
       ],
+      test_suite='nose.collector',
+      tests_require=tests_require,
       entry_points="""
       # -*- Entry points: -*-
       [beaker.backends]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '0.1.1'
+version = '0.1.2'
 
 setup(name='beaker_extensions',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '0.1'
+version = '0.11'
 
 setup(name='beaker_extensions',
       version=version,

--- a/tests/test_couchdb.py
+++ b/tests/test_couchdb.py
@@ -1,0 +1,115 @@
+# coding: utf-8
+from beaker.cache import Cache
+from beaker.exceptions import InvalidCacheBackendError
+from beaker.middleware import CacheMiddleware
+from nose import SkipTest
+from webtest import TestApp
+
+try:
+    import couchdb
+    from couchdb.http import ResourceNotFound
+except ImportError:
+    raise SkipTest("couchdb-python 0.8+ must be installed to perform this test")
+
+db_url = 'localhost:5984'
+db_type = 'couchdb'
+db_name = 'beaker_extension_test'
+
+server = couchdb.Server('http://' + db_url + '/')
+try:
+    server.delete(db_name)
+except ResourceNotFound:
+    pass
+server.create(db_name)
+
+def simple_app(environ, start_response):
+    print "simple_app"
+    extra_args = {}
+    clear = False
+    if environ.get('beaker.clear'):
+        clear = True
+    extra_args['type'] = db_type
+    extra_args['url'] = db_url
+    extra_args['data_dir'] = './cache'
+    extra_args['database'] = db_name
+    cache = environ['beaker.cache'].get_cache('testcache', **extra_args)
+    if clear:
+        cache.clear()
+    try:
+        value = cache.get_value('value')
+    except:
+        value = 0
+    cache.set_value('value', value+1)
+    start_response('200 OK', [('Content-type', 'text/plain')])
+    return ['The current value is: %s' % cache.get_value('value')]
+
+def cache_manager_app(environ, start_response):
+    print "cache_manager_app"
+    cm = environ['beaker.cache']
+    cm.get_cache('test')['test_key'] = 'test value'
+
+    start_response('200 OK', [('Content-type', 'text/plain')])
+    yield "test_key is: %s\n" % cm.get_cache('test')['test_key']
+    cm.get_cache('test').clear()
+
+    try:
+        test_value = cm.get_cache('test')['test_key']
+    except KeyError:
+        yield "test_key cleared"
+    else:
+        yield "test_key wasn't cleared, is: %s\n" % \
+            cm.get_cache('test')['test_key']
+
+def test_has_key():
+    cache = Cache('test', url=db_url, type=db_type, database=db_name)
+    o = object()
+    cache.set_value("test", o)
+    assert cache.has_key("test")
+    assert "test" in cache
+    assert not cache.has_key("foo")
+    assert "foo" not in cache
+    cache.remove_value("test")
+    assert not cache.has_key("test")
+
+def test_has_key_multicache():
+    cache = Cache('test', url=db_url, type=db_type, database=db_name)
+    o = object()
+    cache.set_value("test", o)
+    assert cache.has_key("test")
+    assert "test" in cache
+    cache = Cache('test', url=db_url, type=db_type, database=db_name)
+    assert cache.has_key("test")
+    cache.remove_value('test')
+
+def test_clear():
+    cache = Cache('test', url=db_url, type=db_type, database=db_name)
+    o = object()
+    cache.set_value("test", o)
+    assert cache.has_key("test")
+    cache.clear()
+    assert not cache.has_key("test")
+
+def test_unicode_keys():
+    cache = Cache('test', url=db_url, type=db_type, database=db_name)
+    o = object()
+    cache.set_value(u'hiŏ', o)
+    assert u'hiŏ' in cache
+    assert u'hŏa' not in cache
+    cache.remove_value(u'hiŏ')
+    assert u'hiŏ' not in cache
+    
+def test_increment():
+    app = TestApp(CacheMiddleware(simple_app))
+    res = app.get('/', extra_environ={'beaker.clear':True})
+    assert 'current value is: 1' in res
+    res = app.get('/')
+    assert 'current value is: 2' in res
+    res = app.get('/')
+    assert 'current value is: 3' in res
+
+def test_cache_manager():
+    app = TestApp(CacheMiddleware(cache_manager_app))
+    res = app.get('/')
+    assert 'test_key is: test value' in res
+    assert 'test_key cleared' in res
+


### PR DESCRIPTION
RedisManager currently tries to retrieve the expiry from the value when it's not available through the third argument, but it should not be done in that way because the value is formatted as a tuple containing exptime only when it is invoked from the container thought the manager itself is allowed to be called directly from any other submodules (e.g. session module).
