### PR TITLE
Redis namespace manager fixes (again)

### DIFF
--- a/beaker_extensions/cassandra.py
+++ b/beaker_extensions/cassandra.py
@@ -72,4 +72,4 @@ class CassandraManager(NoSqlManager):
 
 
 class CassandraContainer(Container):
-    namespace_manager = CassandraManager
+    namespace_class = CassandraManager

--- a/beaker_extensions/dynomite_.py
+++ b/beaker_extensions/dynomite_.py
@@ -51,4 +51,4 @@ class DynomiteManager(NoSqlManager):
 
 
 class DynomiteContainer(Container):
-    namespace_manager = DynomiteManager
+    namespace_class = DynomiteManager

--- a/beaker_extensions/nosql.py
+++ b/beaker_extensions/nosql.py
@@ -73,4 +73,4 @@ class NoSqlManager(NamespaceManager):
 
 
 class NoSqlManagerContainer(Container):
-    namespace_manager = NoSqlManager
+    namespace_class = NoSqlManager

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -52,4 +52,4 @@ class RedisManager(NoSqlManager):
 
 
 class RedisContainer(Container):
-    namespace_manager = RedisManager
+    namespace_class = RedisManager

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -28,10 +28,6 @@ class RedisManager(NoSqlManager):
 
         #XXX: beaker.container.Value.set_value calls NamespaceManager.set_value
         # however it(until version 1.6.3) never sets expiretime param. Why?
-        # Fortunately we can access expiretime through value.
-        # >>> value = list(storedtime, expire_argument, real_value)
-        if expiretime is None:
-            expiretime = value[1]
 
         if expiretime:
             self.db_conn.setex(key, expiretime, pickle.dumps(value))

--- a/beaker_extensions/riak.py
+++ b/beaker_extensions/riak.py
@@ -42,4 +42,4 @@ class RiakManager(NoSqlManager):
 
 
 class RiakContainer(Container):
-    namespace_manager = RiakManager
+    namespace_class = RiakManager

--- a/beaker_extensions/ringo.py
+++ b/beaker_extensions/ringo.py
@@ -40,4 +40,4 @@ class RingoManager(NoSqlManager):
 
 
 class RingoContainer(Container):
-    namespace_manager = RingoManager
+    namespace_class = RingoManager

--- a/beaker_extensions/tyrant_.py
+++ b/beaker_extensions/tyrant_.py
@@ -37,4 +37,4 @@ class TokyoTyrantManager(NoSqlManager):
 
 
 class TokyoTyrantContainer(Container):
-    namespace_manager = TokyoTyrantManager
+    namespace_class = TokyoTyrantManager


### PR DESCRIPTION
RedisManager currently tries to retrieve the expiry from the value when it's not available through the third argument, but it should not be done in that way because the value is formatted as a tuple containing exptime only when it is invoked from the container thought the manager itself is allowed to be called directly from any other submodules (e.g. session module).
