### PR TITLE
Redis connection pooling

### DIFF
--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -6,7 +6,7 @@ from beaker_extensions.nosql import NoSqlManager
 from beaker_extensions.nosql import pickle
 
 try:
-    from redis import StrictRedis
+    from redis import StrictRedis, ConnectionPool
 except ImportError:
     raise InvalidCacheBackendError("Redis cache backend requires the 'redis' library")
 
@@ -20,6 +20,7 @@ class RedisManager(NoSqlManager):
                  lock_dir=None,
                  **params):
         self.db = params.pop('db', None)
+        self.connection_pools = {}
         NoSqlManager.__init__(self,
                               namespace,
                               url=url,
@@ -28,13 +29,12 @@ class RedisManager(NoSqlManager):
                               **params)
 
     def open_connection(self, host, port, **params):
-        if (hasattr(self, 'db_conn') and
-            self.db_conn.host == host and
-            self.db_conn.port == port:
-            return
-        self.db_conn = StrictRedis(host=host,
-                                   port=int(port),
-                                   db=self.db,
+        if (not self.connection_pools or
+                self._format_pool_key(host, port, self.db) not in self.connection_pools):
+            self.connection_pools[self._format_pool_key(host, port, self.db)] = ConnectionPool(host=host,
+                                                                                          port=port,
+                                                                                          db=self.db)
+        self.db_conn = StrictRedis(connection_pool=self.connection_pools[self._format_pool_key(host, port, self.db)],
                                    **params)
 
     def __contains__(self, key):
@@ -63,6 +63,9 @@ class RedisManager(NoSqlManager):
 
     def _format_key(self, key):
         return 'beaker:%s:%s' % (self.namespace, key.replace(' ', '\302\267'))
+
+    def _format_pool_key(self, host, port, db):
+        return '{0}:{1}:{2}'.format(host, port, self.db)
 
     def do_remove(self):
         self.db_conn.flush()

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -13,12 +13,29 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 class RedisManager(NoSqlManager):
-    def __init__(self, namespace, url=None, data_dir=None, lock_dir=None, **params):
+    def __init__(self,
+                 namespace,
+                 url=None,
+                 data_dir=None,
+                 lock_dir=None,
+                 **params):
         self.db = params.pop('db', None)
-        NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params)
+        NoSqlManager.__init__(self,
+                              namespace,
+                              url=url,
+                              data_dir=data_dir,
+                              lock_dir=lock_dir,
+                              **params)
 
     def open_connection(self, host, port, **params):
-        self.db_conn = StrictRedis(host=host, port=int(port), db=self.db, **params)
+        if (hasattr(self, 'db_conn') and
+            self.db_conn.host == host and
+            self.db_conn.port == port:
+            return
+        self.db_conn = StrictRedis(host=host,
+                                   port=int(port),
+                                   db=self.db,
+                                   **params)
 
     def __contains__(self, key):
         return self.db_conn.exists(self._format_key(key))

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -29,12 +29,12 @@ class RedisManager(NoSqlManager):
                               **params)
 
     def open_connection(self, host, port, **params):
-        if (not self.connection_pools or
-                self._format_pool_key(host, port, self.db) not in self.connection_pools):
-            self.connection_pools[self._format_pool_key(host, port, self.db)] = ConnectionPool(host=host,
-                                                                                          port=port,
-                                                                                          db=self.db)
-        self.db_conn = StrictRedis(connection_pool=self.connection_pools[self._format_pool_key(host, port, self.db)],
+        pool_key = self._format_pool_key(host, port, self.db)
+        if pool_key not in self.connection_pools:
+            self.connection_pools[pool_key] = ConnectionPool(host=host,
+                                                             port=port,
+                                                             db=self.db)
+        self.db_conn = StrictRedis(connection_pool=self.connection_pools[pool_key],
                                    **params)
 
     def __contains__(self, key):


### PR DESCRIPTION
At the moment, the redis backend creates a new StrictRedis-object for every redis request. This essentially nulls out the built-in connection pooling in the StrictRedis-class. See https://github.com/andymccurdy/redis-py/blob/master/redis/client.py#L271 .
One workaround in other forks has been to explicitly pass in a connection-pool object, but this is not optimal in situations like when using pyramid_beaker to set up the session-connection.

This pull request addresses this in a more general way, by internally keeping a dict of ConnectionPool objects, unique by host, port and db. If a new request is made for a redis db we've seen already, the existing ConnectionPool instance will be used.
