### PR TITLE
Update redis to pickup config-supplied passwords

### DIFF
--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -20,6 +20,7 @@ class RedisManager(NoSqlManager):
                  lock_dir=None,
                  **params):
         self.db = params.pop('db', None)
+        self.dbpass = params.pop('password', None)
         self.connection_pools = {}
         NoSqlManager.__init__(self,
                               namespace,
@@ -33,7 +34,8 @@ class RedisManager(NoSqlManager):
         if pool_key not in self.connection_pools:
             self.connection_pools[pool_key] = ConnectionPool(host=host,
                                                              port=port,
-                                                             db=self.db)
+                                                             db=self.db,
+                                                             password=self.dbpass)
         self.db_conn = StrictRedis(connection_pool=self.connection_pools[pool_key],
                                    **params)
 


### PR DESCRIPTION
Update redis to pickup config-supplied passwords.

StrictRedis doesn't use extra kwargs if using connection_pool, so it misses the password, etc.

Also, for whatever reason, "params" in open_connection() is an empty dict for me when I printed debug output, i.e. {}, no password.
