### PR TITLE
Updated Riak backend to work with the latest version of the client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 *.py?
 *.egg-info
 *.swp

--- a/beaker_extensions/riak_.py
+++ b/beaker_extensions/riak_.py
@@ -19,22 +19,22 @@ class RiakManager(NoSqlManager):
         NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params)
 
     def open_connection(self, host, port):
-        self.db_conn = riak.RiakClient(host=host, port=int(port))
+        self.db_conn = riak.RiakClient(protocol='pbc', host=host, pb_port=int(port))
         self.bucket = self.db_conn.bucket('beaker_cache')
 
     def __contains__(self, key):
-        return self.bucket.get(self._format_key(key)).exists()
+        return self.bucket.get(self._format_key(key)).exists
 
     def set_value(self, key, value):
         val = self.bucket.get(self._format_key(key))
-        if not val.exists():
+        if not val.exists:
             self.bucket.new(self._format_key(key), value).store()
         else:
-            val.set_data(value)
+            val.data = value
             val.store()
 
     def __getitem__(self, key):
-        return self.bucket.get(self._format_key(key)).get_data()
+        return self.bucket.get(self._format_key(key)).data
 
     def __delitem__(self, key):
         self.bucket.get(self._format_key(key)).delete()


### PR DESCRIPTION
In addition to updating the client I also switched to using protocol buffers (protocol='pbc') by default (as it's provides lower latency).
