### PR TITLE
Fix redis connection pool sharing.

### DIFF
--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -13,6 +13,9 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 class RedisManager(NoSqlManager):
+
+    connection_pools = {}
+
     def __init__(self,
                  namespace,
                  url=None,
@@ -21,7 +24,6 @@ class RedisManager(NoSqlManager):
                  **params):
         self.db = params.pop('db', None)
         self.dbpass = params.pop('password', None)
-        self.connection_pools = {}
         NoSqlManager.__init__(self,
                               namespace,
                               url=url,


### PR DESCRIPTION
This fixes things so that redis connection pools are shared between `RedisManager` instances.

I'm pretty sure this was the original intent of the code.  AFAICT, `RedisManager.open_connection` gets called exactly once in the normal lifecycle of a `RedisManager`.  This means the currently the `collection_pools` dict always get exactly one (newly created) pool stored in it (and thus is mostly pointless.)

When using beaker sessions, a new namespace manager is created for each request, which means that currently a new connection is made to the redis server for each request.  This fixes that.
