### PR TITLE
Allow JSON serializer configuration setting.

### DIFF
--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from beaker.exceptions import InvalidCacheBackendError
 
@@ -57,10 +58,15 @@ class RedisManager(NoSqlManager):
         if (expiretime is None) and (type(value) is tuple):
             expiretime = value[1]
 
-        if expiretime:
-            self.db_conn.setex(key, expiretime, pickle.dumps(value, 2))
+        if self.serializer == 'json':
+            serialized_value = json.dumps(value, ensure_ascii=True)
         else:
-            self.db_conn.set(key, pickle.dumps(value, 2))
+            serialized_value = pickle.dumps(value, 2)
+
+        if expiretime:
+            self.db_conn.setex(key, expiretime, serialized_value)
+        else:
+            self.db_conn.set(key, serialized_value)
 
     def __delitem__(self, key):
         self.db_conn.delete(self._format_key(key))


### PR DESCRIPTION
I didn't see a built-in way to use JSON serialization in redis/beaker so I made this configurable and have it fall back to pickle.
